### PR TITLE
Return the created result so the callbackContext is kept

### DIFF
--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -157,7 +157,7 @@ public class WebIntent extends CordovaPlugin {
         if (this.callbackContext != null) {
             PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
             result.setKeepCallback(true);
-            this.callbackContext.success(intent.getDataString());
+            this.callbackContext.sendPluginResult(result);
         }
     }
 


### PR DESCRIPTION
By calling success the CallbackContext was being finished and subsequent callbacks failed. Instead, return the PluginResult we just created.
