### PR TITLE
Attempting patch to set new intent on resume

### DIFF
--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -154,6 +154,9 @@ public class WebIntent extends CordovaPlugin {
 
     @Override
     public void onNewIntent(Intent intent) {
+        
+        this.cordova.getActivity().setIntent(intent);
+        
         if (this.callbackContext != null) {
             PluginResult result = new PluginResult(PluginResult.Status.OK, intent.getDataString());
             result.setKeepCallback(true);


### PR DESCRIPTION
Implements suggested fix for issues #2 & #7, results in URL for most recent intent being available to current activity.
